### PR TITLE
Use Buffer.from instead of new Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ var encoded = btoa(decoded)
 However in Node, it's done like so:
 
 ``` javascript
-var encoded = new Buffer(decoded).toString('base64')
+var encoded = Buffer.from(decoded).toString('base64')
 ```
 
 You can easily check if `Buffer` exists and switch between the approaches

--- a/btoa-node.js
+++ b/btoa-node.js
@@ -1,3 +1,3 @@
 module.exports = function btoa(str) {
-  return new Buffer(str).toString('base64')
+  return Buffer.from(str).toString('base64')
 }


### PR DESCRIPTION
The buffer constructor has been deprecated since node 6, which fell out of maintenance a good while ago.

atob-lite was similarly updated a couple years ago: https://github.com/hughsk/atob-lite/blob/master/atob-node.js